### PR TITLE
Corrects site-title to be always site title

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,7 +5,7 @@
             <div class="container">
                 <div class="site-title-wrapper">
                     <h1 class="site-title">
-                        <a title="{{ .Title }}" href="{{ .Site.BaseURL }}">{{ .Title }}</a>
+                        <a title="{{ .Site.Title }}" href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
                     </h1>
                     <a class="button-square button-jump-top js-jump-top" href="#">
                         <i class="fa fa-angle-up"></i>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -29,7 +29,7 @@
                             </a>
                         {{ else }}
                             <h1 class="site-title">
-                                <a title="{{ .Title }}" href="{{ .Site.BaseURL }}">{{ .Title }}</a>
+                                <a title="{{ .Site.Title }}" href="{{ .Site.BaseURL }}">{{ .Site.Title }}</a>
                             </h1>
                         {{ end }}
                         <a class="button-square" href="{{ .Site.BaseURL }}index.xml"><i class="fa fa-rss"></i></a>


### PR DESCRIPTION
before: site-title is set to the page/post title.
after: it is always set to the site title.