### PR TITLE
Adds support to restructuredText markup

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -25,6 +25,11 @@
         <script src="{{ .Site.BaseURL }}js/jquery-1.11.3.min.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.5/highlight.min.js"></script>
         <script src="{{ .Site.BaseURL }}js/jquery.fitvids.js"></script>
+		<script type="text/javascript">
+			$.hugo = {
+				"Markup": {{ .Markup }}
+			};
+		</script>
         <script src="{{ .Site.BaseURL }}js/scripts.js"></script>
     </body>
 </html>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -13,6 +13,9 @@
         <link rel="stylesheet" href="{{ .Site.BaseURL }}css/normalize.css">
         <link rel="stylesheet" href="{{ .Site.BaseURL }}css/highlight.css">
         <link rel="stylesheet" href="{{ .Site.BaseURL }}css/style.css">
+		{{ if eq .Markup "rst" }}
+		<link rel="stylesheet" href="{{ .Site.BaseURL }}css/restructuredtext.css">
+		{{ end }}
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300italic,400italic,600italic,700italic,400,600,700,300&subset=latin,cyrillic-ext,latin-ext,cyrillic">
         <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
     </head>

--- a/static/css/restructuredtext.css
+++ b/static/css/restructuredtext.css
@@ -1,0 +1,4 @@
+.literal {
+	font-family: monospace, monospace;
+    font-size: 1em;
+}

--- a/static/js/scripts.js
+++ b/static/js/scripts.js
@@ -15,6 +15,10 @@ jQuery(function($) {
 
         $('html, body').animate({'scrollTop': 0});
     });
+
+	if ( $.hugo.Markup == "rst" ) {
+		$('pre.code').wrapInner( "<code></code>" );
+	}
 });
 
 hljs.initHighlightingOnLoad();


### PR DESCRIPTION
CSS:
introduces a new css file with rules adapted to the way rst2html
tool parses the .rst markup to html. Mainly/currently only
applying the proper css rule for inline code elements which is in
rst land is a ".literal" class to a "tt" element.

JS:
for highlight.js to work on code blocks generated by rst2html, the
code blocks (wrapped in <pre class="literal-block code") has to be
further wrapped in <code></code>.

To do that, I introduced a '$.hugo' namespace that should hold
whatever hugo variables we need along to the js land.
