### PR TITLE
Move list item bullet outside the item

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -45,7 +45,6 @@ a {
   text-decoration: none; }
 
 ul, ol {
-  list-style-position: inside;
   line-height: 1.4;
   margin: 0 0 20px;
   padding: 0; }

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -42,7 +42,6 @@ a {
 }
 
 ul, ol {
-    list-style-position: inside;
     line-height: 1.4;
     margin: 0 0 20px;
     padding: 0;


### PR DESCRIPTION
This makes lists look better when the source document is ReStructuredText.

For instance if you have the following .rst list:

    * **Abc**.

      Def

It generates the following DOM elements:

![screenshot from 2017-01-04 19-21-03](https://cloud.githubusercontent.com/assets/980838/21653766/04c55676-d2b3-11e6-94ec-0c2000325f5e.png)

The `<p>` tag in combination with the bullet causes the paragraph to fall down a line below the bullet:

![screenshot from 2017-01-04 19-23-32](https://cloud.githubusercontent.com/assets/980838/21653826/4e39e768-d2b3-11e6-878e-4a13e4883e9d.png)
