### PR TITLE
Improve the footnote formatting

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -276,6 +276,10 @@ table {
   padding: 0 0 2px; }
 .post-content:last-child {
   margin-bottom: 0; }
+.post-content .footnote {
+  margin-bottom: 0; }
+  .post-content .footnote .label + td {
+    width: 100%; }
 
 .post-footer {
   margin-top: 5px; }

--- a/static/sass/style.scss
+++ b/static/sass/style.scss
@@ -313,6 +313,14 @@ table {
     }
 
     &:last-child { margin-bottom: 0; }
+
+    .footnote {
+        margin-bottom: 0;
+
+        .label + td {
+            width: 100%;
+        }
+    }
 }
 
 .post-footer { margin-top: 5px; }


### PR DESCRIPTION
Assume we have this .rst post:

```
+++
title = "Example"
date = "2010-10-10"
+++

A text [#]_, that has [#]_ references [#]_.

References
----------

.. [#] "Abc" https://en.wikipedia.org/
.. [#] "Def" https://f-droid.org/repository/browse/
.. [#] "Ghi" https://f-droid.org/
```

Before it looked like:

![screenshot from 2017-01-04 21-17-58](https://cloud.githubusercontent.com/assets/980838/21657743/fff3c130-d2c3-11e6-96d9-4835ffb1ee5e.png)

Now:

![screenshot from 2017-01-04 21-18-28](https://cloud.githubusercontent.com/assets/980838/21657752/04a304b6-d2c4-11e6-8894-1afb22e37078.png)
