### PR TITLE
Prevent <pre> from overflowing when JS is disabled

### DIFF
--- a/static/dist/styles.css
+++ b/static/dist/styles.css
@@ -87,7 +87,7 @@ ul li:last-of-type, ol li:last-of-type { margin-bottom: 0; }
 blockquote { border-left: 1px dotted #f03838; margin: 40px 0; padding: 5px 30px; }
 blockquote p { color: #aeadad; display: block; font-style: italic; margin: 0; width: 100%; }
 img { display: block; margin: 40px 0; width: auto; max-width: 100%; }
-pre { background: #f1f0ea; border: 1px solid #dddbcc; border-radius: 3px; margin: 0 0 20px; padding: 10px; font-size: 16px; }
+pre { background: #f1f0ea; border: 1px solid #dddbcc; border-radius: 3px; margin: 0 0 20px; overflow-x: auto; padding: 10px; font-size: 16px; }
 pre code { padding: 0; }
 code { padding: 2px 4px; font-size: 90%; color: #f03838; background-color: #f1f0ea; border-radius: 4px; }
 hr { border: none; border-bottom: 1px dotted #303030; margin: 45px 0; }

--- a/static/styles/style.scss
+++ b/static/styles/style.scss
@@ -80,6 +80,7 @@ pre {
     border: 1px solid #DDDBCC;
     border-radius: 3px;
     margin: 0 0 20px;
+    overflow-x: auto;
     padding: 10px;
     font-size: 16px;
 


### PR DESCRIPTION
When JS is enabled, JSHint adds overflow auto to the `<code>` tag that's wrapped by `<pre>`.

But when JS is disabled it overflows:
![screenshot from 2017-01-06 22-28-26](https://cloud.githubusercontent.com/assets/980838/21733684/190f7090-d460-11e6-8bee-b40f89c6a554.png)

With this change:

![screenshot from 2017-01-06 22-27-45](https://cloud.githubusercontent.com/assets/980838/21733675/0638db5a-d460-11e6-8a26-1e32dca0abc0.png)

Furthermore, this also prevents `<pre>` from overflowing when the code block originates from an .rst file, since those don't seem to utilize `<code>` and JSHint.