### PR TITLE
Center the jump-to-top footer button on mobile

### DIFF
--- a/static/dist/styles.css
+++ b/static/dist/styles.css
@@ -210,6 +210,8 @@ table tr { border-bottom: 1px dotted #aeadad; }
  .share { float: left; margin-top: 20px; }
  .share a { margin: 0 5px 0 0; }
  .footer { margin-top: 50px; }
+ .footer .site-title-wrapper { text-align: center; }
+ .footer .button-jump-top { clear: both; display: inline-block; float: none; }
 }
 @media only screen and (max-width: 400px) {
  .site-header { padding-top: 40px; }

--- a/static/styles/style.scss
+++ b/static/styles/style.scss
@@ -686,6 +686,16 @@ table {
 
     .footer {
         margin-top: 50px;
+
+        .site-title-wrapper {
+            text-align: center;
+        }
+
+        .button-jump-top {
+            clear: both;
+            display: inline-block;
+            float: none;
+        }
     }
 }
 


### PR DESCRIPTION
Fixes jbub/ghostwriter#21

Before:

![screen shot 2017-01-07 at 09 11 29](https://cloud.githubusercontent.com/assets/980838/21740419/f9b94efa-d4b9-11e6-8130-34b5ac5cac3f.png)

After:

![screen shot 2017-01-07 at 09 10 51](https://cloud.githubusercontent.com/assets/980838/21740420/0185b54c-d4ba-11e6-9555-7c10840288b5.png)
