### PR TITLE
Add settings to control visible social media share buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ disqusShortname = "XXX"
     stackoverflow = "https://stackoverflow.com/users/XXX/YYY"
     email = "XXX@example.com"
     opengraph = true
+    shareTwitter = true
+    shareFacebook = true
+    shareGooglePlus = true
 
 [Permalinks]
     post = "/:year/:month/:day/:filename/"

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -25,6 +25,9 @@ googleAnalytics = "XXX"
     stackoverflow = "https://stackoverflow.com/users/XXX/YYY"
     email = "XXX@example.com"
     opengraph = true
+    shareTwitter = true
+    shareFacebook = true
+    shareGooglePlus = true
 
 [Permalinks]
     post = "/:year/:month/:day/:filename/"

--- a/layouts/partials/post-footer.html
+++ b/layouts/partials/post-footer.html
@@ -11,22 +11,28 @@
     {{ end}}
 
     <div class="share">
-        <a class="icon-twitter" href="https://twitter.com/share?text={{ .Title }}&url={{ .Permalink }}"
-            onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;">
-            <i class="fa fa-twitter"></i>
-            <span class="hidden">Twitter</span>
-        </a>
+        {{ if or (not (isset .Site.Params "sharetwitter")) .Site.Params.shareTwitter }}
+            <a class="icon-twitter" href="https://twitter.com/share?text={{ .Title }}&url={{ .Permalink }}"
+                onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;">
+                <i class="fa fa-twitter"></i>
+                <span class="hidden">Twitter</span>
+            </a>
+        {{ end }}
 
-        <a class="icon-facebook" href="https://www.facebook.com/sharer/sharer.php?u={{ .Permalink }}"
-            onclick="window.open(this.href, 'facebook-share','width=580,height=296');return false;">
-            <i class="fa fa-facebook"></i>
-            <span class="hidden">Facebook</span>
-        </a>
+        {{ if or (not (isset .Site.Params "sharefacebook")) .Site.Params.shareFacebook }}
+            <a class="icon-facebook" href="https://www.facebook.com/sharer/sharer.php?u={{ .Permalink }}"
+                onclick="window.open(this.href, 'facebook-share','width=580,height=296');return false;">
+                <i class="fa fa-facebook"></i>
+                <span class="hidden">Facebook</span>
+            </a>
+        {{ end }}
 
-        <a class="icon-google-plus" href="https://plus.google.com/share?url={{ .Permalink }}"
-           onclick="window.open(this.href, 'google-plus-share', 'width=490,height=530');return false;">
-           <i class="fa fa-google-plus"></i>
-            <span class="hidden">Google+</span>
-        </a>
+        {{ if or (not (isset .Site.Params "sharegoogleplus")) .Site.Params.shareGooglePlus }}
+            <a class="icon-google-plus" href="https://plus.google.com/share?url={{ .Permalink }}"
+              onclick="window.open(this.href, 'google-plus-share', 'width=490,height=530');return false;">
+              <i class="fa fa-google-plus"></i>
+                <span class="hidden">Google+</span>
+            </a>
+        {{ end }}
     </div>
 </footer>


### PR DESCRIPTION
If the share setting hasn't been set for a social media button, it falls back on `true`. This ensures that this change doesn't break any existing installs.