### PR TITLE
Add config option to customize the date format

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ disqusShortname = "XXX"
     shareTwitter = true
     shareFacebook = true
     shareGooglePlus = true
+    dateFormat = "Mon, Jan 2, 2006"
 
 [Permalinks]
     post = "/:year/:month/:day/:filename/"

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -28,6 +28,7 @@ googleAnalytics = "XXX"
     shareTwitter = true
     shareFacebook = true
     shareGooglePlus = true
+    dateFormat = "Mon, Jan 2, 2006"
 
 [Permalinks]
     post = "/:year/:month/:day/:filename/"

--- a/layouts/partials/post-header.html
+++ b/layouts/partials/post-header.html
@@ -4,7 +4,7 @@
         <p class="post-description" itemprop="description">{{ .Description }}</p>
     {{ end }}
     <p class="post-date">
-        <span>Published <time datetime="{{ .Date.Format "2006-01-02" }}" itemprop="datePublished">{{ .Date.Format "Mon, Jan 2, 2006" }}</time></span>
+        <span>Published <time datetime="{{ .Date.Format "2006-01-02" }}" itemprop="datePublished">{{ dateFormat (default "Mon, Jan 2, 2006" .Site.Params.dateFormat) .Date }}</time></span>
         <span>by</span>
         <span itemscope="" itemprop="author" itemtype="https://schema.org/Person">
             <span itemprop="name">

--- a/layouts/partials/post-stub.html
+++ b/layouts/partials/post-stub.html
@@ -1,7 +1,7 @@
 <li class="post-stub" itemprop="blogPost" itemscope="" itemtype="https://schema.org/BlogPosting">
     <a href="{{ .Permalink }}" itemprop="url" title="Go to post detail">
         <h4 class="post-stub-title" itemprop="name">{{ .Title }}</h4>
-        <time class="post-stub-date" datetime="{{ .Date.Format "2006-01-02" }}">Published {{ .Date.Format "Mon, Jan 2, 2006" }}</time>
+        <time class="post-stub-date" datetime="{{ .Date.Format "2006-01-02" }}">Published {{ dateFormat (default "Mon, Jan 2, 2006" .Site.Params.dateFormat) .Date }}</time>
         {{ with .Params.featured }}
             <span class="post-stub-tag">Featured</span>
         {{ end }}


### PR DESCRIPTION
With this change it's possible to customize the date format with an option in Hugo's config file. The dates that are affect are the ones in the blog post list, and in the one in the post's header (below its title). I also set `"Mon, Jan 2, 2006"` to the default format, so if the config option isn't present it doesn't break or change anything from previous versions.