### PR TITLE
Fixed a link based on Tags in footer

### DIFF
--- a/layouts/partials/post-footer.html
+++ b/layouts/partials/post-footer.html
@@ -3,8 +3,9 @@
         <p class="post-tags">
             <span>Tagged:</span>
             {{ $len := len .Params.tags }}
+            {{ $baseurl := trim .Site.BaseURL "/" }}
             {{ range $index, $tag := .Params.tags }}
-                <a href="/tags/{{ . | urlize }}/">{{ . }}</a>
+                <a href="{{ $baseurl }}/tags/{{ . | urlize }}/">{{ . }}</a>
                 {{- if lt $index (sub $len 1) -}}, {{ end }}
             {{ end }}
         </p>


### PR DESCRIPTION
Hi.

I'm trying to use the ghostwriter theme for my site. The baseURL configured for my site includes a subdirectory like "https://pxaka.tokyo/blog". In this case, a generated link for pages based on Tags is invalid because the link path is constructed without the subdirectory like "https://pxaka.tokyo/tags/<tag>". So I put some codes to post-footer.html so that the link can be generated correctly. I'm new to Go lang so I'd appreciate it if you could check the changes. At least, the applied code works well in my site.

Best,
Takaaki
