### PR TITLE
Do not load Disqus when running on localhost

### DIFF
--- a/layouts/partials/disqus.html
+++ b/layouts/partials/disqus.html
@@ -1,5 +1,21 @@
 {{ if .Site.DisqusShortname }}
     <div class="comments">
-        {{ template "_internal/disqus.html" . }}
+        <div id="disqus_thread"></div>
+        <script type="text/javascript">
+
+            (function() {
+                // Don't ever inject Disqus on localhost--it creates unwanted
+               // discussions from 'localhost:1313' on your Disqus account...
+                if (window.location.hostname == "localhost")
+                    return;
+
+                var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
+                var disqus_shortname = '{{ .Site.DisqusShortname }}';
+                dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
+                (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+            })();
+        </script>
+        <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
+        <a href="http://disqus.com/" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
     </div>
 {{ end }}


### PR DESCRIPTION
This is taken directly from the [Hugo documentation](https://gohugo.io/extras/comments/) instead of using the _internal/disqus.html template. This is done because if you are running in localhost mode to test things, a lot of useless discussions get created on Disqus. This seems to be a fairly common change among Hugo templates, I'm not sure why they don't just make this a configurable option for the internal template!