### PR TITLE
Add a new "extra-in-head" customizable partial

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,6 @@ disqusShortname = "XXX"
     url = "/page/about/"
     weight = 4
 ```
+
+You can also inject arbitrary HTML into `<head>` simply by overriding the `extra-in-head.html`
+partial, which is meant for that purpose.

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -17,6 +17,7 @@
         {{ if .RSSLink }}
             <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml">
         {{ end }}
+        {{ partial "extra-in-head.html" . }}
     </head>
     <body>
         {{ template "_internal/google_analytics.html" . }}


### PR DESCRIPTION
The partial is empty as it is meant as an extension point for users, who can use it to inject arbitrary HTML into `<head>` without having to maintain a fork of the theme.

Background: https://discourse.gohugo.io/t/how-to-override-css-classes-with-hugo/3033/9