### PR TITLE
Update default post archetype to Hugo 0.30

### DIFF
--- a/archetypes/default.md
+++ b/archetypes/default.md
@@ -1,6 +1,8 @@
 +++
-title = ""
+title = "{{ humanize .TranslationBaseName | title }}"
 description = ""
 author = ""
+date = {{ .Date }}
 tags = []
+draft = true
 +++


### PR DESCRIPTION
For the command `hugo new post/hello.md`, post Hugo 0.24 the auto-population of fields like `title`, `date`, etc. aren't done if these fields are just set to `""` without actually scripting the needed values.