### PR TITLE
Remove chrome=1 from X-UA-Compatible meta element

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -2,7 +2,7 @@
 <html{{ if .Site.Params.opengraph }} prefix="og: http://ogp.me/ns#"{{ end }}>
     <head>
         <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <title>{{ .Title }} &middot; {{ .Site.Author.name }}</title>
         <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{ if .IsPage }}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}">
         <meta name="HandheldFriendly" content="True">


### PR DESCRIPTION
The Google Chrome Frame was retired four years ago; see discussion at https://stackoverflow.com/questions/22059060/is-it-still-valid-to-use-ie-edge-chrome-1 for more information. Also, having 'chrome=1' results in that meta line not validating with the W3C Validator.