### PR TITLE
Add ability to render _index.md on list pages

### DIFF
--- a/layouts/post/list.html
+++ b/layouts/post/list.html
@@ -3,6 +3,9 @@
 <div id="post-index" class="container">
     {{ partial "intro.html" . }}
 
+    <!-- "{{.Content}}" pulls from the markdown content of the corresponding _index.md -->
+    {{.Content}}
+
     <ol class="post-list">
         {{ $pag := .Paginate .Pages }}
         {{ range $pag.Pages }}


### PR DESCRIPTION
Hugo let's you add  content and front matter to the homepage. See: https://gohugo.io/templates/homepage/#add-content-and-front-matter-to-the-homepage

This change adds the .Content Tag to render a _index.md on a list page. 