### PR TITLE
Footnotes style fix with HTML generated by blackfriday

### DIFF
--- a/static/dist/site.css
+++ b/static/dist/site.css
@@ -101,8 +101,8 @@ table tr { border-bottom: 1px dotted #aeadad; }
 .post-line:after { border-bottom: 1px dotted #303030; content: ""; display: block; margin: 40px auto 0; width: 100px; }
 .post-content a:hover { border-bottom: 1px dotted #f03838; padding: 0 0 2px; }
 .post-content:last-child { margin-bottom: 0; }
-.post-content .footnote { border-spacing: 0; margin-bottom: 0; }
-.post-content .footnote .label+td { width: 100%; }
+.post-content .footnotes { border-spacing: 0; margin-bottom: 0; }
+.post-content .footnotes .label+td { width: 100%; }
 .post-content .gist tr { border-bottom: 0; }
 .post-footer { margin-top: 5px; }
 .post-tags, .share { color: #aeadad; font-size: 14px; }

--- a/static/styles/site/style.scss
+++ b/static/styles/site/style.scss
@@ -330,7 +330,7 @@ table {
 
     &:last-child { margin-bottom: 0; }
 
-    .footnote {
+    .footnotes {
         border-spacing: 0;
         margin-bottom: 0;
 


### PR DESCRIPTION
Hello,

Just a small fix to define the class `footnotes` (instead of `footnote`) in order to be compliant with output generated by the [Blackfriday Markdown](https://github.com/russross/blackfriday/) processor.

```HTML
<div class="footnotes">
...
</div>
```
https://github.com/russross/blackfriday/blob/d3b5b032dc8e8927d31a5071b56e14c89f045135/html.go#L466

Side note: Are you interested by this feature of Hugo that permits to handle transformation of SCSS to CSS during site generation: [Hugo Pipes allows the processing of SASS and SCSS files](https://gohugo.io/hugo-pipes/scss-sass/)? If so, I could draft a PR 😄 

Best.