### PR TITLE
Remove leading & trailing whitespaces, rework comma insertion between tags

### DIFF
--- a/layouts/partials/post-footer.html
+++ b/layouts/partials/post-footer.html
@@ -1,36 +1,34 @@
 <footer class="post-footer clearfix">
-    {{ if .Params.tags }}
+    {{- with .Params.tags }}
         <p class="post-tags">
             <span>Tagged:</span>
-            {{ $len := len .Params.tags }}
-            {{ range $index, $tag := .Params.tags }}
+            {{- range $index, $tag := . -}}
+                {{- if $index -}}, {{ end }}
                 <a href="{{ "/tags/" | relLangURL }}{{ . | urlize }}/">{{ . }}</a>
-                {{- if lt $index (sub $len 1) -}}, {{ end }}
-            {{ end }}
+            {{- end }}
         </p>
-    {{ end}}
+    {{ end -}}
 
     <div class="share">
-        {{ if .Site.Params.shareTwitter }}
+        {{- if .Site.Params.shareTwitter }}
             <a class="icon-twitter" href="https://twitter.com/share?text={{ .Title }}&url={{ .Permalink }}"
                 onclick="window.open(this.href, 'twitter-share', 'width=550,height=235');return false;" aria-label="Share on Twitter">
                 <i class="fa fa-twitter" aria-hidden="true"></i>
             </a>
-        {{ end }}
+        {{- end }}
 
-        {{ if .Site.Params.sharefacebook }}
+        {{- if .Site.Params.sharefacebook }}
             <a class="icon-facebook" href="https://www.facebook.com/sharer/sharer.php?u={{ .Permalink }}"
                 onclick="window.open(this.href, 'facebook-share','width=580,height=296');return false;" aria-label="Share on Facebook">
                 <i class="fa fa-facebook" aria-hidden="true"></i>
             </a>
-        {{ end }}
+        {{- end }}
 
-
-        {{ if .Site.Params.shareLinkedIn }}
+        {{- if .Site.Params.shareLinkedIn }}
             <a class="icon-linkedin" href="https://www.linkedin.com/shareArticle?mini=true&title={{ .Title }}&url={{ .Permalink }}&summary={{ .Description }}"
                onclick="window.open(this.href, 'linkedin-share', 'width=554,height=481');return false;" aria-label="Share on LinkedIn">
                <i class="fa fa-linkedin" aria-hidden="true"></i>
             </a>
-        {{ end }}
+        {{- end }}
     </div>
 </footer>


### PR DESCRIPTION
Hello,

Just a small, and pretty useless, improvement to the post footer to 

* remove leading & trailing whitespaces (that can become numerous if shares are not activated) thanks to ability to trim them in [Go templates](https://gohugo.io/templates/introduction/#whitespace),
* rework the way tags are separated by commas, credits [SO](https://stackoverflow.com/questions/21305865/golang-separating-items-with-comma-in-template?noredirect=1&lq=1).

Best