### PR TITLE
Move to gtag.js

### DIFF
--- a/layouts/partials/google_analytics.html
+++ b/layouts/partials/google_analytics.html
@@ -1,0 +1,11 @@
+  {{ with .Site.GoogleAnalytics }}
+   <script async src="https://www.googletagmanager.com/gtag/js?id={{ . }}"></script>
+   <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date()));
+    
+    gtag('config', '{{ . }}')
+    </script>
+       
+  {{ end }}

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -22,9 +22,9 @@
         {{ partial "exponea.html" . }}
         {{ partial "fathom.html" . }}
         {{ partial "plausible.html" . }}
+        {{ partial "google_analytics.html" . }}
     </head>
     <body>
-        {{ template "_internal/google_analytics.html" . }}
 
         <div id="wrapper">
             <header class="site-header">


### PR DESCRIPTION
Hi,

Great work with this theme. This PR moves Google Analytics to gtag.js, "the future of Google Analytics".

