### PR TITLE
Fix build error for Hugo v0.140.2

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -13,7 +13,7 @@
                 </div>
 
                 <p class="footer-copyright">
-                    <span>&copy; {{ .Site.LastChange.Format "2006" }} / Powered by <a href="https://gohugo.io/">Hugo</a></span>
+                    <span>&copy; {{ now.Year }} / Powered by <a href="https://gohugo.io/">Hugo</a></span>
                 </p>
                 <p class="footer-copyright">
                     <span><a href="https://github.com/roryg/ghostwriter">Ghostwriter theme</a> By <a href="http://jollygoodthemes.com">JollyGoodThemes</a></span>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -13,7 +13,7 @@
                 </div>
 
                 <p class="footer-copyright">
-                    <span>&copy; {{ now.Year }} / Powered by <a href="https://gohugo.io/">Hugo</a></span>
+                    <span>&copy; {{ .Site.Lastmod | time.Format "2006" }} / Powered by <a href="https://gohugo.io/">Hugo</a></span>
                 </p>
                 <p class="footer-copyright">
                     <span><a href="https://github.com/roryg/ghostwriter">Ghostwriter theme</a> By <a href="http://jollygoodthemes.com">JollyGoodThemes</a></span>


### PR DESCRIPTION
I have installed the newest version of hugo
```bash
hugo version
hugo v0.140.2-aae02ca612a02e085c08366a9c9279f4abb39d94 linux/amd64 BuildDate=2024-12-30T15:01:53Z VendorInfo=gohugoio
```

And my blog failed to build:

```bash
❯ hugo server -D

Start building sites … 
hugo v0.140.2-aae02ca612a02e085c08366a9c9279f4abb39d94 linux/amd64 BuildDate=2024-12-30T15:01:53Z VendorInfo=gohugoio

ERROR deprecated: .Site.LastChange was deprecated in Hugo v0.123.0 and will be removed in Hugo 0.141.0. Use .Site.Lastmod instead.
Built in 98 ms
Error: error building site: logged 1 error(s)
```

Using `now.Year` seems to be the recommended function now: https://discourse.gohugo.io/t/how-do-i-display-the-current-year/1174/13. 